### PR TITLE
release as draft by the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,16 +42,6 @@ jobs:
       - name: Create release
         if: steps.check-release.outputs.exist == 'false'
         run: |
-          gh release create ${{ steps.retrive-version.outputs.version }} --generate-notes
+          gh release create ${{ steps.retrive-version.outputs.version }} --generate-notes --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update major tag
-        if: steps.check-release.outputs.exist == 'false'
-        run: |
-          TAG=${{ steps.retrive-version.outputs.version }} # v1.2.3
-          MAJOR="${TAG%%.*}"                               # v1
-
-          MESSAGE="Release ${TAG}"
-
-          git tag -fa $MAJOR -m "${MESSAGE}"
-          git push --force origin $MAJOR

--- a/.github/workflows/update_major_tag.yml
+++ b/.github/workflows/update_major_tag.yml
@@ -1,0 +1,28 @@
+name: Update major tag
+
+on:
+  release:
+    types:
+      - released
+
+permissions:
+  contents: write
+
+jobs:
+  update_major_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - name: Update major tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/} # v1.2.3
+          MAJOR="${TAG%%.*}"           # v1
+
+          MESSAGE="Release ${TAG}"
+
+          git tag -fa "${MAJOR}" -m "${MESSAGE}"
+          git push --force origin "${MAJOR}"


### PR DESCRIPTION
resolves #20 

1. The release workflow releases as a draft with a new tag
2. I accept and publish it operationally
3. After the new release is published, a major version will be updated by `update_major_tag` workflow