### PR TITLE
use GitHub Apps token instead of default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.TOKEN_GENERATOR_APP_ID }}
+          private_key: ${{ secrets.TOKEN_GENERATOR_APP_PRIVATE_KEY }}
       - name: Retrieve version
         id: retrive-version
         run: |
@@ -29,7 +34,7 @@ jobs:
           RELEASE_EXIST=$(cat /tmp/gh_release_view.log | grep -q "release not found" && echo "false" || echo "true")
           echo "exist=$RELEASE_EXIST" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Create tag
         if: steps.check-release.outputs.exist == 'false'
         run: |
@@ -39,9 +44,11 @@ jobs:
           TAG=${{ steps.retrive-version.outputs.version }}
           git tag $TAG
           git push origin $TAG
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Create release
         if: steps.check-release.outputs.exist == 'false'
         run: |
           gh release create ${{ steps.retrive-version.outputs.version }} --generate-notes --draft
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release_version_check.yml
+++ b/.github/workflows/release_version_check.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.TOKEN_GENERATOR_APP_ID }}
+          private_key: ${{ secrets.TOKEN_GENERATOR_APP_PRIVATE_KEY }}
       - name: Write current release versions
         run: |
           curl -s \
@@ -47,4 +52,4 @@ jobs:
 
           gh pr create -B main -H $BRANCH -t "$COMMIT_MESSAGE" -b "This pull-request is created by GitHub Actions. Run $RUN_URL"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
When a workflow run pushes commits using the default `GITHUB_TOKEN`, workflows will not run.
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

For example that workflows do not invoked: https://github.com/shirakiya/setup-tfcmt/pull/35

GitHub Apps token resolves the problem, so I decided to introduce it.