### PR TITLE
add release note setting

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - renovate


### PR DESCRIPTION
Changes by Renovate (label: `renovate`) is noisy, so will not include the PRs in the release note.