### PR TITLE
create release as draft

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -1,6 +1,6 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	release = true
+	release = draft
 	changelog = true
 	versionFile = package.json


### PR DESCRIPTION
Releases created automatically don't publish action to GitHub marketplace.
ref. https://github.com/orgs/community/discussions/7941#discussioncomment-4188921

For that reason, I decide that let tagpr create a release as draft and publish it manually.