### PR TITLE
update major tag automatically at release

### DIFF
--- a/.github/workflows/update_major_tag.yml
+++ b/.github/workflows/update_major_tag.yml
@@ -1,0 +1,26 @@
+name: Update major tag
+
+on:
+  release:
+    types:
+      - released
+
+permissions:
+  contents: write
+
+jobs:
+  update_major_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Update major tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/} # v1.2.3
+          MAJOR="${TAG%%.*}"           # v1
+          MESSAGE="Release ${TAG}"
+          git tag -fa "${MAJOR}" -m "${MESSAGE}"
+          git push --force origin "${MAJOR}"


### PR DESCRIPTION
Currently, the major tag (`v1`) is updated by my hand. `tagpr` does not maintain it automatically.
So we need to prepare this workflow.