### PR TITLE
remove trailingComma setting because it is to default of Prettier v3

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,7 +5,6 @@
   "semi": false,
   "singleQuote": false,
   "quoteProps": "as-needed",
-  "trailingComma": "all",
   "bracketSpacing": true,
   "arrowParens": "always"
 }


### PR DESCRIPTION
See https://prettier.io/blog/2023/07/05/3.0.0.html#change-the-default-value-for-trailingcomma-to-all-11479httpsgithubcomprettierprettierpull11479-by-fiskerhttpsgithubcomfisker-13143httpsgithubcomprettierprettierpull13143-by-sosukesuzukihttpsgithubcomsosukesuzuki