### PR TITLE
update Node.js to v20 as runtime in action and development

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: The version of Node.js to be setup
     required: false
-    default: 16
+    default: 20
 runs:
   using: composite
   steps:

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: ""
 runs:
-  using: node16
+  using: node20
   main: dist/setup/index.js
 branding:
   icon: terminal

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/jest": "29.5.8",
-        "@types/node": "18.18.9",
+        "@types/node": "20.9.0",
         "@typescript-eslint/eslint-plugin": "6.10.0",
         "@typescript-eslint/parser": "6.10.0",
         "@vercel/ncc": "0.38.1",
@@ -27,7 +27,7 @@
         "typescript": "5.2.2"
       },
       "engines": {
-        "node": "16.20.2"
+        "node": "20.9.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1406,9 +1406,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7265,9 +7265,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/shirakiya/setup-tfcmt/issues"
   },
   "engines": {
-    "node": "16.20.2"
+    "node": "20.9.0"
   },
   "dependencies": {
     "@actions/core": "1.10.1",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.8",
-    "@types/node": "18.18.9",
+    "@types/node": "20.9.0",
     "@typescript-eslint/eslint-plugin": "6.10.0",
     "@typescript-eslint/parser": "6.10.0",
     "@vercel/ncc": "0.38.1",


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

You can see the change logs of these packages with https://github.com/shirakiya/setup-tfcmt/pull/158