### PR TITLE
review TypeScript configration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,3 +10,5 @@ jobs:
       - uses: ./.github/actions/setup-node
       - name: Check lint and format
         run: npm run lint
+      - name: Check types
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Set up specific version of tfcmt in your GitHub Actions workflow.",
   "main": "dist/setup/index.js",
   "scripts": {
-    "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "package": "esbuild src/setup_entrypoint.ts --bundle --platform=node --target=node24 --outfile=dist/setup/index.js --format=cjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2024",
     "module": "commonjs",
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
1. add `compilerOptions.types` to tsconfig
2. update `compilerOptions.target` in tsconfig  to `es2024`
3. rename compiling with tsc from `build` to `typecheck` as npm scripts
4. run `npm run typecheck` in CI